### PR TITLE
remove snmp-exporter and secure blackbox exporter

### DIFF
--- a/group_vars/exporters.yml
+++ b/group_vars/exporters.yml
@@ -1,0 +1,2 @@
+---
+blackbox_exporter_web_listen_address: "127.0.0.1:9115"

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -54,7 +54,7 @@ prometheus_scrape_configs:
     module: [http_2xx]
   static_configs:
   - targets:
-    - "http://{{ ansible_host }}:9100"
+    - "http://localhost:9100"
   relabel_configs:
   - source_labels: [__address__]
     target_label: __param_target

--- a/group_vars/web.yml
+++ b/group_vars/web.yml
@@ -5,8 +5,6 @@ port_mapping:
   prometheus: 9090
   alertmanager: 9093
   node: 9100
-  blackbox: 9115
-  snmp: 9116
 
 caddy_update: true
 caddy_systemd_capabilities_enabled: true

--- a/hosts
+++ b/hosts
@@ -9,5 +9,8 @@ demo
 [grafana]
 demo
 
+[exporters]
+demo
+
 [web]
 demo

--- a/playbooks/02_monitoring.yml
+++ b/playbooks/02_monitoring.yml
@@ -10,7 +10,6 @@
   hosts: prometheus
   roles:
   - cloudalchemy.blackbox-exporter
-  - cloudalchemy.snmp-exporter
   - cloudalchemy.prometheus
   - cloudalchemy.alertmanager
   tags:


### PR DESCRIPTION
- remove snmp-exporter deployment
- blackbox-exporter should listen on localhost only
- remove snmp and blackbox exporters from caddy

Signed-off-by: paulfantom <pawel@krupa.net.pl>