### PR TITLE
.circleci: fix incorrect ssh fingerprint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
     - checkout
     - add_ssh_keys:
         fingerprints:
-        - "46:a1:bb:55:6e3a:a5:2f:ea:13:46:ae:24:f0:19"
+        - "46:a1:bb:55:6e:cd:3a:a5:2f:ea:13:46:ae:24:f0:19"
     - attach_workspace:
         at: .
     - run: cp -v go/bin/random playbooks/files/random


### PR DESCRIPTION
I have no idea why it worked, but fingerprint was wrong.