### PR TITLE
More random_exporters; fixes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Prometheus demo monitoring site
+# Prometheus monitoring demo site
 
 [![Build Status](https://circleci.com/gh/prometheus/demo-site.svg?style=svg)](https://circleci.com/gh/prometheus/demo-site)
-[![License](https://img.shields.io/badge/license-MIT%20License-brightgreen.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/license-Apache%20License-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![IRC](https://img.shields.io/badge/chat-on%20freenode-blue.svg)](http://webchat.freenode.net/?channels=prometheus)
 
 ## [demo.prometheus.io](https://demo.prometheus.io)
 
 This repository provides a demo site for [prometheus](https://github.com/prometheus/prometheus), [alertmanager](https://github.com/prometheus/alertmanager), prometheus exporters, and [grafana](https://github.com/grafana/grafana).
-Site is provisioned with ansible running every day and on almost all commits to master branch. Everything is fully automated with travis ci pipeline. If you want to check `ansible-playbook` output, go to [last build](https://travis-ci.org/prometheus/demo-site).
+Site is provisioned with ansible running every day and on all commits to master branch. Everything is fully automated with travis ci pipeline. If you want to check `ansible-playbook` output, go to [last build](https://travis-ci.org/prometheus/demo-site).
 
 Have a look at configuration files in [group_vars/](group_vars).
 
@@ -18,8 +18,6 @@ All applications should be running on their default ports.
 | App name          | Address (HTTP)                                       | Address (HTTPS)                                           |
 |-------------------|------------------------------------------------------|-----------------------------------------------------------|
 | node_exporter     | [demo.prometheus.io:9100][node_exporter_http]     | [node.demo.prometheus.io][node_exporter_https]         |
-| snmp_exporter     | [demo.prometheus.io:9116][snmp_exporter_http]     | [snmp.demo.prometheus.io][snmp_exporter_https]         |
-| blackbox_exporter | [demo.prometheus.io:9115][blackbox_exporter_http] | [blackbox.demo.prometheus.io][blackbox_exporter_https] |
 | prometheus        | [demo.prometheus.io:9090][prometheus_http]        | [prometheus.demo.prometheus.io][prometheus_https]      |
 | alertmanager      | [demo.prometheus.io:9093][alertmanager_http]      | [alertmanager.demo.prometheus.io][alertmanager_https]  |
 | grafana           | [demo.prometheus.io:3000][grafana_http]           | [grafana.demo.prometheus.io][grafana_https]            |
@@ -79,12 +77,6 @@ demo site is deployed using [Cloud Alchemy](https://github.com/cloudalchemy) ans
 
 [node_exporter_http]: http://demo.prometheus.io:9100
 [node_exporter_https]: https://node.demo.prometheus.io
-
-[snmp_exporter_http]: http://demo.prometheus.io:9116
-[snmp_exporter_https]: https://snmp.demo.prometheus.io
-
-[blackbox_exporter_http]: http://demo.prometheus.io:9115
-[blackbox_exporter_https]: https://blackbox.demo.prometheus.io
 
 [prometheus_http]: http://demo.prometheus.io:9090
 [prometheus_https]: https://prometheus.demo.prometheus.io

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -1,4 +1,10 @@
 ---
+random_exporter_addresses:
+- "{{ ansible_host }}:8999"
+- "{{ ansible_host }}:8998"
+- "{{ ansible_host }}:8997"
+- "{{ ansible_host }}:8996"
+
 prometheus_web_external_url: "http://{{ ansible_host }}:9090"
 prometheus_storage_retention: "31d"
 
@@ -19,6 +25,8 @@ prometheus_targets:
     - "{{ ansible_host }}:9093"
     labels:
       env: demo
+  random:
+  - targets: "{{ random_exporter_addresses }}"
 
 prometheus_scrape_configs:
 - job_name: "prometheus"
@@ -28,9 +36,9 @@ prometheus_scrape_configs:
     - "{{ ansible_host }}:9090"
 - job_name: "random"
   metrics_path: "/metrics"
-  static_configs:
-  - targets:
-    - "{{ ansible_host }}:8999"
+  file_sd_configs:
+  - files:
+    - "/etc/prometheus/file_sd/random.yml"
 - job_name: "caddy"
   metrics_path: "/metrics"
   static_configs:

--- a/playbooks/02_monitoring.yml
+++ b/playbooks/02_monitoring.yml
@@ -22,7 +22,7 @@
   tags:
   - grafana
 
-- name: Setup random number exporter
+- name: Setup random exporters
   hosts: all
   tasks:
   - name: Copy random_exporter binary
@@ -35,29 +35,28 @@
     notify: random_exporter restart
   - name: Copy systemd service file
     copy:
-      dest: /etc/systemd/system/random_exporter.service
+      dest: "/etc/systemd/system/random_exporter@.service"
       mode: 0644
-      content: "{{ random_exporter_systemd_service }}"
+      content: |
+        # Ansible managed
+        [Unit]
+        Description=Random Metrics Exporter on %i
+        After=network.target
+        [Service]
+        Type=simple
+        User=nobody
+        Group=nogroup
+        ExecStart=/usr/local/bin/random_exporter -listen-address=:%i
+        SyslogIdentifier=random_exporter
+        Restart=always
+        [Install]
+        WantedBy=multi-user.target
     notify: random_exporter restart
   handlers:
   - name: random_exporter restart
     systemd:
-      name: random_exporter
+      name: "random_exporter@{{ item }}"
       state: started
       daemon_reload: true
       enabled: true
-  vars:
-    random_exporter_systemd_service: |
-      # Ansible managed
-      [Unit]
-      Description=Random Metrics Exporter
-      After=network.target
-      [Service]
-      Type=simple
-      User=nobody
-      Group=nogroup
-      ExecStart=/usr/local/bin/random_exporter -listen-address=:8999
-      SyslogIdentifier=random_exporter
-      Restart=always
-      [Install]
-      WantedBy=multi-user.target
+    with_items: "{{ random_exporter_addresses }}"


### PR DESCRIPTION
- Add better random_exporter systemd service file which allows specifying multiple random exporters (right now it set to 4) - fixes #3 
- minor fixes in readme
  - fixed license badge
  - removed links to blackbox and snmp exporters

Number of random_exporters is controlled by `random_exporter_addresses` list in `group_vars/prometheus.yml`