### PR TITLE
Merge pull request #23 from paulfantom/mixins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,31 @@ jobs:
         paths:
         - go/bin
 
+  mixins:
+    executor: golang
+    steps:
+    - run: go get -u github.com/google/go-jsonnet/cmd/jsonnet
+    - run: go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+    - run: git clone --depth 1 https://github.com/prometheus/prometheus.git
+    - run: |
+        cd prometheus/documentation/prometheus-mixin
+        jb install
+        make prometheus_alerts.yaml
+    - run: git clone --depth 1 https://github.com/prometheus/node_exporter.git
+    - run: |
+        cd node_exporter/docs/node-mixin
+        jb install
+        make node_alerts.yaml node_rules.yaml
+    - run: |
+        mkdir rules
+        cp -v prometheus/documentation/prometheus-mixin/*.yaml node_exporter/docs/node-mixin/*.yaml rules/
+        # cloudalchemy.ansible-prometheus expects rule files to have `.rules` extension
+        for i in rules/*.yaml; do mv -v $i ${i%yaml}rules; done
+    - persist_to_workspace:
+        root: .
+        paths:
+        - rules/
+
   test:
     executor: python
     steps:
@@ -50,6 +75,7 @@ jobs:
     - attach_workspace:
         at: .
     - run: cp -v go/bin/random playbooks/files/random
+    - run: cp -rv rules playbooks/files/
     - restore_cache:
         keys:
         - deps-{{ checksum "requirements.txt" }}
@@ -63,6 +89,7 @@ workflows:
   commit:
     jobs:
     - build
+    - mixins
     - test
     - deploy:
         requires:
@@ -82,8 +109,10 @@ workflows:
             - master
     jobs:
     - build
+    - mixins
     - test
     - deploy:
         requires:
         - build
         - test
+        - mixins

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,18 @@ jobs:
     steps:
     - run: go get -u github.com/google/go-jsonnet/cmd/jsonnet
     - run: go get -u github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
-    - run: git clone --depth 1 https://github.com/prometheus/prometheus.git
+    - run: |
+        git clone --depth 1 --no-checkout --filter=blob:none https://github.com/prometheus/prometheus.git prometheus
+        cd prometheus
+        git checkout master -- documentation/prometheus-mixin
     - run: |
         cd prometheus/documentation/prometheus-mixin
         jb install
         make prometheus_alerts.yaml
-    - run: git clone --depth 1 https://github.com/prometheus/node_exporter.git
+    - run: |
+        git clone --depth 1 --no-checkout --filter=blob:none https://github.com/prometheus/node_exporter.git node_exporter
+        cd node_exporter
+        git checkout master -- docs/node-mixin
     - run: |
         cd node_exporter/docs/node-mixin
         jb install

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ roles/*
 ara*
 .vault-password
 playbooks/files/random
+playbooks/files/rules/
+playbooks/files/dashboards/

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -14,6 +14,23 @@ prometheus_alertmanager_config:
   - targets:
     - "{{ ansible_host }}:9093"
 
+prometheus_alert_rules_files:
+- rules/*.rules
+
+prometheus_alert_rules:
+- alert: Watchdog
+  expr: vector(1)
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    description: 'This is an alert meant to ensure that the entire alerting pipeline is functional.
+      This alert is always firing, therefore it should always be firing in Alertmanager
+      and always fire against a receiver. There are integrations with various notification
+      mechanisms that send a notification when this alert is not firing. For example the
+      "DeadMansSnitch" integration in PagerDuty.'
+    summary: 'Ensure entire alerting pipeline is functional'
+
 prometheus_targets:
   node:
   - targets:


### PR DESCRIPTION
generate prometheus and node_exporter mixins and deploy them with ansible

Currently only alerts and recording rules are created due to https://github.com/prometheus/prometheus/pull/6602 and problems with [cloudalchemy.grafana](https://github.com/cloudalchemy/ansible-grafana) role.

Signed-off-by: paulfantom <pawel@krupa.net.pl>