### PR TITLE
.circleci: make mixins stage required for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ workflows:
         requires:
         - build
         - test
+        - mixins
         filters:
           branches:
             only: master


### PR DESCRIPTION
Without it deployments after merging anything to `master` may fail.