### PR TITLE
Update prometheus to 2.16.0

### DIFF
--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -8,8 +8,6 @@ random_exporter_addresses:
 prometheus_web_external_url: "http://{{ ansible_host }}:9090"
 prometheus_storage_retention: "31d"
 
-prometheus_version: 2.16.0-rc.0
-
 prometheus_alertmanager_config:
 - scheme: http
   static_configs:


### PR DESCRIPTION
I have also created
https://github.com/cloudalchemy/ansible-prometheus/pull/267

But I think we can keep the version explicit here, it will quickly
enable us to update to release candidates, instead of playing the game
of adding/removing lines each time.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>