### PR TITLE
disable caddy updates

### DIFF
--- a/group_vars/web.yml
+++ b/group_vars/web.yml
@@ -6,7 +6,8 @@ port_mapping:
   alertmanager: 9093
   node: 9100
 
-caddy_update: true
+caddy_download: false
+caddy_update: false
 caddy_systemd_capabilities_enabled: true
 caddy_systemd_restart_startlimitinterval: 3600
 caddy_features: http.prometheus


### PR DESCRIPTION
Caddy v1 website changed API and current download link doesn't work.
This is a temporary stop-gap solution until https://github.com/caddy-ansible/caddy-ansible/pull/6 is merged and we can migrate to v2

/cc @SuperQ 