### PR TITLE
Remove obsolete `prometheus` config

### DIFF
--- a/group_vars/web/web.yml
+++ b/group_vars/web/web.yml
@@ -11,7 +11,6 @@ caddy_config: |
   {{ ansible_host }} {
     try_files {path}.html {path}
     root * /var/www/demo/
-    prometheus
   }
   {% for name, port in port_mapping.items() %}
   {{ name }}.{{ ansible_host }} {


### PR DESCRIPTION
Remove the obsolete `prometheus` config from Caddy. It now automatically
listens on the default admin localhost:2019.

Signed-off-by: Ben Kochie <superq@gmail.com>