### PR TITLE
Enable missing file_server in Caddy

### DIFF
--- a/group_vars/web/web.yml
+++ b/group_vars/web/web.yml
@@ -11,6 +11,7 @@ caddy_config: |
   {{ ansible_host }} {
     try_files {path}.html {path}
     root * /var/www/demo/
+    file_server
   }
   {% for name, port in port_mapping.items() %}
   {{ name }}.{{ ansible_host }} {


### PR DESCRIPTION
Fix demo site homepage content by enabling the file_server directive.

Signed-off-by: Ben Kochie <superq@gmail.com>