### PR TITLE
group_vars: disable caddy updates

### DIFF
--- a/group_vars/web/web.yml
+++ b/group_vars/web/web.yml
@@ -5,6 +5,9 @@ port_mapping:
   alertmanager: 9093
   node: 9100
 
+# TODO(paulfantom): reenable when https://github.com/caddy-ansible/caddy-ansible/issues/13 is fixed
+caddy_update: false
+
 caddy_systemd_capabilities_enabled: true
 caddy_systemd_restart_startlimitinterval: 3600
 caddy_config: |


### PR DESCRIPTION
Recently demo-site deploys stopped working due to an issue with caddy updates (reported in https://github.com/caddy-ansible/caddy-ansible/issues/13). With this PR deploys should start working again.