### PR TITLE
Temporarily disable caddy updates

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -2,9 +2,9 @@
 - import_playbook: playbooks/00_system.yml
   tags:
   - system
-- import_playbook: playbooks/01_webserver.yml
-  tags:
-  - webserver
+#- import_playbook: playbooks/01_webserver.yml
+#  tags:
+#  - webserver
 - import_playbook: playbooks/02_monitoring.yml
   tags:
   - monitoring


### PR DESCRIPTION
Seems like the ansible role managing caddy is broken. For now, let's disable it to allow clean updates for monitoring stack.