### PR TITLE
Fix alertmanager_external_url depreaction

### DIFF
--- a/group_vars/alertmanager.yml
+++ b/group_vars/alertmanager.yml
@@ -1,5 +1,5 @@
 ---
-alertmanager_external_url: "http://{{ ansible_host }}:9093"
+alertmanager_web_external_url: "http://{{ ansible_host }}:9093"
 alertmanager_slack_api_url: "http://example.org"
 alertmanager_receivers:
 - name: slack


### PR DESCRIPTION
fatal: [demo]: FAILED! => {"changed": false, "msg": "Please use
`alertmanager_web_external_url` instead of `alertmanager_external_url`"}

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>