### PR TITLE
Add a node metric threshold example

### DIFF
--- a/group_vars/exporters.yml
+++ b/group_vars/exporters.yml
@@ -1,2 +1,6 @@
 ---
 blackbox_exporter_web_listen_address: "127.0.0.1:9115"
+
+node_cpu_utilization_thresholds:
+  critical: 99
+  warning: 95

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -35,6 +35,20 @@ prometheus_alert_rules:
       mechanisms that send a notification when this alert is not firing. For example the
       "DeadMansSnitch" integration in PagerDuty.'
     summary: 'Ensure entire alerting pipeline is functional'
+- alert: NodeCPUUtilizationHigh
+  expr: |
+    instance:node_cpu_utilisation:rate5m * 100
+      > ignoring (severity)
+    node_cpu_utilization_percent_threshold{severity="critical"}
+  for: 10m
+  labels:
+    severity: critical
+  annotations:
+    description: |
+      The node CPU utilization ({{ $value }}%) has been over threshold
+      ({{ query "node_cpu_utilization_percent_threshold{severity=\"critical\",instance=\"$labels.instance\"}"}}%)
+      for 10 minutes.
+    summary: Node CPU Utilization is high
 
 prometheus_targets:
   node:

--- a/playbooks/02_monitoring.yml
+++ b/playbooks/02_monitoring.yml
@@ -66,3 +66,16 @@
       daemon_reload: true
       enabled: true
     with_items: "{{ random_exporter_addresses }}"
+
+- name: Add node textfile examples
+  hosts: all
+  tasks:
+  - name: Node CPU threshold
+    template:
+      src: node_metrics.prom.j2
+      dest: "{{ node_exporter_textfile_dir }}/node_metrics.prom"
+      owner: root
+      group: root
+      mode: 0644
+  tags:
+  - node_exporter

--- a/playbooks/templates/node_metrics.prom.j2
+++ b/playbooks/templates/node_metrics.prom.j2
@@ -1,0 +1,5 @@
+# HELP node_cpu_utilization_percent_threshold The CPU utilization percent which triggers an alert.
+# TYPE node_cpu_utilization_percent_threshold gauge
+{% for severity, value in node_cpu_utilization_thresholds.items() -%}
+node_cpu_utilization_percent_threshold{severity="{{ severity }}"} {{ level }}
+{% endfor -%}


### PR DESCRIPTION
Add an example of how to use a node_exporter textfile metric as a
threshold for alerting.

Signed-off-by: SuperQ <superq@gmail.com>