### PR TITLE
fixing circleci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,12 +81,25 @@ jobs:
         at: .
     - run: cp -v go/bin/random playbooks/files/random
     - run: cp -rv rules dashboards playbooks/files/
-    - run: sudo pip install --cache-dir ~/.cache/pip -q -r requirements.txt
+    - run: sudo pip install --cache-dir ~/.cache/pip -q -r molecule/test-requirements.txt
     - run: ansible-galaxy install -f -r roles/requirements.yml
     # Remove encrypted file so ansible won't try to decrypt it
     - run: rm group_vars/grafana/vault
-    - run: |
-        ansible-playbook --check -e "{'grafana_security': {'admin_user': 'admin', admin_password: 'secret' }}" site.yml
+    - setup_remote_docker
+    # - run: |
+    #    ansible-playbook -e "{'grafana_security': {'admin_user': 'admin', admin_password: 'secret' }}" site.yml
+    - run: molecule --debug dependency
+    - run: molecule --debug lint
+    - run: molecule --debug cleanup
+    - run: molecule --debug destroy
+    - run: molecule --debug syntax
+    - run: molecule --debug create
+    - run: molecule --debug prepare
+    - run: molecule --debug converge
+    # - run: molecule --debug idempotence
+    - run: molecule --debug verify
+    - run: molecule --debug cleanup
+    - run: molecule --debug destroy
 
   deploy:
     executor: python

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,6 @@ jobs:
     # Remove encrypted file so ansible won't try to decrypt it
     - run: rm group_vars/grafana/vault
     - setup_remote_docker
-    # - run: |
-    #    ansible-playbook -e "{'grafana_security': {'admin_user': 'admin', admin_password: 'secret' }}" site.yml
     - run: molecule --debug dependency
     - run: molecule --debug lint
     - run: molecule --debug cleanup
@@ -96,6 +94,7 @@ jobs:
     - run: molecule --debug create
     - run: molecule --debug prepare
     - run: molecule --debug converge
+    # TODO
     # - run: molecule --debug idempotence
     - run: molecule --debug verify
     - run: molecule --debug cleanup

--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -1,11 +1,11 @@
 ---
 random_exporter_addresses:
-- "{{ ansible_host }}:8999"
-- "{{ ansible_host }}:8998"
-- "{{ ansible_host }}:8997"
-- "{{ ansible_host }}:8996"
+- "{{ ansible_host | default(inventory_hostname) }}:8999"
+- "{{ ansible_host | default(inventory_hostname) }}:8998"
+- "{{ ansible_host | default(inventory_hostname) }}:8997"
+- "{{ ansible_host | default(inventory_hostname) }}:8996"
 
-prometheus_web_external_url: "http://{{ ansible_host }}:9090"
+prometheus_web_external_url: "http://{{ ansible_host | default(inventory_hostname)  }}:9090"
 prometheus_storage_retention: "31d"
 
 prometheus_config_flags_extra:
@@ -17,7 +17,7 @@ prometheus_alertmanager_config:
 - scheme: http
   static_configs:
   - targets:
-    - "{{ ansible_host }}:9093"
+    - "{{ ansible_host | default(inventory_hostname) }}:9093"
 
 prometheus_alert_rules_files:
 - rules/*.rules
@@ -52,15 +52,19 @@ prometheus_alert_rules:
       {% endraw -%}
     summary: Node CPU Utilization is high
 
+# The following variable should be set to 'inventory_hostname' (in group_vars, host_vars, or elsewhere)
+# if you haven't specified 'ansible_host' in the inventory.
+prometheus_hostnamelookupkey: "{{ prometheus_hostnamelookupkey | default('ansible_host') }}"
+
 prometheus_targets:
   node:
   - targets:
-      "{{ groups['all'] | map('extract', hostvars, ['ansible_host']) | map('regex_replace', '$', ':9100') | list }}"
+      "{{ groups['all'] | map('extract', hostvars, [prometheus_hostnamelookupkey]) | map('regex_replace', '$', ':9100') | list }}"
     labels:
       env: demo
   alertmanager:
   - targets:
-    - "{{ ansible_host }}:9093"
+    - "{{ ansible_host | default(inventory_hostname) }}:9093"
     labels:
       env: demo
   random:
@@ -71,7 +75,7 @@ prometheus_scrape_configs:
   metrics_path: "/metrics"
   static_configs:
   - targets:
-    - "{{ ansible_host }}:9090"
+    - "{{ ansible_host | default(inventory_hostname) }}:9090"
 - job_name: "random"
   metrics_path: "/metrics"
   file_sd_configs:
@@ -85,7 +89,7 @@ prometheus_scrape_configs:
 - job_name: "grafana"
   static_configs:
   - targets:
-    - "{{ ansible_host }}:3000"
+    - "{{ ansible_host | default(inventory_hostname) }}:3000"
 - job_name: "node"
   file_sd_configs:
   - files:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,2 @@
+---
+- import_playbook: ../../site.yml

--- a/molecule/default/host_vars/bionic.yml
+++ b/molecule/default/host_vars/bionic.yml
@@ -1,0 +1,3 @@
+---
+prometheus_hostnamelookupkey: 'inventory_hostname'
+grafana_security: {'admin_user': 'admin', admin_password: 'secret'}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,32 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: bionic
+    pre_build_image: true
+    image: quay.io/paulfantom/molecule-systemd:ubuntu-18.04
+    docker_host: "${DOCKER_HOST:-unix://var/run/docker.sock}"
+    groups:
+      - python3
+      - prometheus
+      - alertmanager
+      - grafana
+      - exporters
+      - web
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /var/lib/docker
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: prepare.yml
+    converge: converge.yml
+  inventory:
+    links:
+      group_vars: ../../group_vars/
+      host_vars: host_vars/
+verifier:
+  name: testinfra

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,0 +1,19 @@
+---
+- name: Prepare
+  hosts: all
+  become: true
+  gather_facts: false
+  tasks:
+  - name: install packages
+    package:
+      name: "{{ item }}"
+      state: present
+      update_cache: true
+    with_items:
+      - openssh-server
+      - openssh-client
+  - name: Create dir
+    file:
+      path: "/run/sshd"
+      state: directory
+      mode: 0755

--- a/molecule/test-requirements.txt
+++ b/molecule/test-requirements.txt
@@ -1,0 +1,12 @@
+ansible>=2.10.0,<3.0.0
+jmespath
+git-lfs
+ansible-lint
+molecule>=3.0.0
+molecule-docker
+docker
+ansible-lint>=3.4.0
+testinfra>=1.7.0
+jmespath
+selinux
+passlib

--- a/playbooks/00_system.yml
+++ b/playbooks/00_system.yml
@@ -1,14 +1,16 @@
 ---
 - name: Install python
   hosts: all
+  become: true
   gather_facts: false
   tasks:
   - name: Install python
-    raw: "apt update && apt install -y python3"
+    raw: "sleep 10 && apt-get update && apt-get install -y python3"
     changed_when: false
 
 - name: Apply security restrictions
   hosts: all
+  become: true
   roles:
   - dev-sec.ssh-hardening
   - dev-sec.os-hardening
@@ -28,6 +30,7 @@
 
 - name: Configure automatic updates
   hosts: all
+  become: true
   roles:
   - jnv.unattended-upgrades
   vars:


### PR DESCRIPTION
CircleCI builds on pull requests have been failing.  It looks like one reason is because they are trying to run ansible on the production server.  It would be safer to test pull requests in an isolated docker container instead, using molecule tests.

A discovery is that although 'ansible_host' appears to be one of those magical automatic ansible variables, it isn't.   
If you want to use 'ansible_host' in the inventory you have to set it manually.  Many real-world ansible deployments might not have 'ansible_host' configured.   As an alternative, why not allow the playbooks to use 'inventory_hostname'.  So, that has been added here.
