### PR TITLE
Fix Prometheus logo link

### DIFF
--- a/playbooks/files/index.html
+++ b/playbooks/files/index.html
@@ -16,7 +16,7 @@
     <div class="container-fluid">
       <div class="row">
         <div class="col-sm-12 text-white text-center">
-          <img height="100px" src="https://github.com/prometheus/docs/raw/master/static/prometheus_logo.png"/>
+          <img height="100px" src="https://raw.githubusercontent.com/prometheus/docs/main/static/prometheus_logo.png"/>
           <h1>Prometheus</h1>
           <p class="font-italic">From Metrics to Insight</p><br>
         </div>


### PR DESCRIPTION
The link was `404`ing because of the `master` to `main` switch, and also GitHub seems to be redirecting to the `raw.githubusercontent.com` subdomain so might as well use it here.