### PR TITLE
WIP: refactor: use caddy over api

### DIFF
--- a/group_vars/web/web.yml
+++ b/group_vars/web/web.yml
@@ -5,19 +5,44 @@ port_mapping:
   alertmanager: 9093
   node: 9100
 
-# TODO(paulfantom): reenable when https://github.com/caddy-ansible/caddy-ansible/issues/13 is fixed
-caddy_update: false
+# # TODO(paulfantom): reenable when https://github.com/caddy-ansible/caddy-ansible/issues/13 is fixed
+# caddy_update: false
+# 
+# caddy_systemd_capabilities_enabled: true
+# caddy_systemd_restart_startlimitinterval: 3600
+# caddy_config: |
+#   {{ ansible_host }} {
+#     try_files {path}.html {path}
+#     root * /var/www/demo/
+#     file_server
+#   }
+#   {# for name, port in port_mapping.items() %}
+#   {{ name }}.{{ ansible_host }} {
+#     reverse_proxy 127.0.0.1:{{ port }}
+#   }
+#   {% endfor #}
 
-caddy_systemd_capabilities_enabled: true
-caddy_systemd_restart_startlimitinterval: 3600
-caddy_config: |
-  {{ ansible_host }} {
-    try_files {path}.html {path}
-    root * /var/www/demo/
-    file_server
-  }
-  {% for name, port in port_mapping.items() %}
-  {{ name }}.{{ ansible_host }} {
-    reverse_proxy 127.0.0.1:{{ port }}
-  }
-  {% endfor %}
+caddy_json_config:
+  apps:
+    http:
+      servers:
+        demo:
+          listen:
+            - ":80"
+            - ":443"
+          routes:
+            - match:
+                - host:
+                    - "{{ ansible_host }}"
+              handle:
+                - handler: "static_response"
+                  body: "{{ lookup('ansible.builtin.file', 'index.html') }}"
+{% for name, port in port_mapping.items() %}
+              - match:
+                - host:
+                    - "{{ name }}.{{ ansible_host }}"
+              handle:
+                - handler: "reverse_proxy"
+                  upstreams:
+                    - dial: "127.0.0.1:{{ port }}"
+{% endfor %}

--- a/playbooks/01_webserver.yml
+++ b/playbooks/01_webserver.yml
@@ -2,23 +2,23 @@
 - name: Setup HTTP server
   hosts: web
   roles:
-    - caddy_ansible.caddy_ansible
-  pre_tasks:
-    - name: Ensure webdirs exists
-      ansible.builtin.file:
-        mode: '0755'
-        path: "{{ item }}"
-        state: directory
-      loop:
-        - /var/www/demo
-        - /var/www/demo/img
-    - name: Ensure portal site exists
-      ansible.builtin.copy:
-        mode: '0644'
-        src: index.html
-        dest: /var/www/demo/index.html
-    - name: Copy digitalocean image
-      ansible.builtin.get_url:
-        url: "https://github.com/prometheus/demo-site/raw/prometheus/playbooks/files/img/digitalocean.png"
-        dest: "/var/www/demo/img/digitalocean.png"
-        mode: 0644
+    - maxhoesel.caddy.caddy_server
+      #   pre_tasks:
+      #     - name: Ensure webdirs exists
+      #       ansible.builtin.file:
+      #         mode: '0755'
+      #         path: "{{ item }}"
+      #         state: directory
+      #       loop:
+      #         - /var/www/demo
+      #         - /var/www/demo/img
+      #     - name: Ensure portal site exists
+      #       ansible.builtin.copy:
+      #         mode: '0644'
+      #         src: index.html
+      #         dest: /var/www/demo/index.html
+      #     - name: Copy digitalocean image
+      #       ansible.builtin.get_url:
+      #         url: "https://github.com/prometheus/demo-site/raw/prometheus/playbooks/files/img/digitalocean.png"
+      #         dest: "/var/www/demo/img/digitalocean.png"
+      #         mode: 0644

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -7,11 +7,11 @@ collections:
   type: galaxy
 - name: devsec.hardening
   type: galaxy
+- name: maxhoesel.caddy
 
 roles:
 - name: cloudalchemy.grafana
 
 # EXTRAS
-- name: caddy_ansible.caddy_ansible
 - name: jnv.unattended-upgrades
   version: v1.7.1


### PR DESCRIPTION
By using the caddy api we can skip all directory creation, file uploads, etc. tasks.