### PR TITLE
Fix favicon link

### DIFF
--- a/playbooks/files/index.html
+++ b/playbooks/files/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#31363b">
     <meta name="author" content="Pawel Krupa">
-    <link rel="icon" href="https://github.com/prometheus/docs/raw/master/static/prometheus_logo.png">
+    <link rel="icon" href="https://raw.githubusercontent.com/prometheus/docs/main/static/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <title>Prometheus</title>
   </head>


### PR DESCRIPTION
Hi @LeviHarrison, on a related note, the logo link fix #67 is not reflected in current deployment of the demo website at https://demo.do.prometheus.io/, would you be able to trigger a new build?