### PR TITLE
Re-enable Grafana metrics

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -8,6 +8,9 @@ grafana_auth:
     org_name: "Main Org."
     org_role: Viewer
 
+grafana_metrics:
+  enabled: true
+
 grafana_datasources:
   - name: "Prometheus"
     type: "prometheus"


### PR DESCRIPTION
The Grafana role disables metrics unless the `grafana_metrics` is a non-empty dict.