### PR TITLE
Create MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,3 @@
+* Ben Kochie <superq@gmail.com> @SuperQ
+* Garðar Arnarsson <github@gardar.net> @gardar
+* Paweł Krupa <paulfantom@gmail.com> @paulfantom


### PR DESCRIPTION
I have just copied the MAINTAINERS.md file from
https://github.com/prometheus-community/ansible , because that repository is related.

Due to this relationship, @gardar and @paulfantom have push rights for https://github.com/prometheus . Listing them as maintainers here formalizes those permissions.

@gardar and @paulfantom, once this is merged, I'll also invite you as regular members of the Prometheus GH org (rather than just "outside collaborators", as you are categorized now).

It would be great if all three of you could approve this PR. @SuperQ @gardar @paulfantom