### PR TITLE
Disable Grafana alerting

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -17,4 +17,7 @@ grafana_datasources:
     access: "proxy"
     url: "http://{{ ansible_host }}:9090"
     isDefault: true
+
 grafana_dashboards: []
+
+grafana_alerting: {}

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -9,7 +9,7 @@ collections:
   type: galaxy
 - name: grafana.grafana
   type: galaxy
-  version: ">=2.2.0"
+  version: ">=5.2.0"
 
 roles:
 # EXTRAS


### PR DESCRIPTION
Grafana legacy alerting has been removed from Grafana 11.0.
* Bump Grafana collection.