### PR TITLE
Update Prometheus feature flags

### DIFF
--- a/group_vars/prometheus.yml
+++ b/group_vars/prometheus.yml
@@ -10,8 +10,8 @@ prometheus_storage_retention: "31d"
 
 prometheus_config_flags_extra:
   enable-feature:
-    - promql-at-modifier
-    - promql-negative-offset
+    - extra-scrape-metrics
+    - promql-per-step-stats
 
 prometheus_alertmanager_config:
   - scheme: http


### PR DESCRIPTION
Update supported feature flags[0].

Enable new flags:
- extra-scrape-metrics[0]
- promql-per-step-stats[1]

Remove obsolete flags:
- promql-at-modifier
- promql-negative-offset

[0]: https://prometheus.io/docs/prometheus/latest/feature_flags/#extra-scrape-metrics
[1]: https://prometheus.io/docs/prometheus/latest/feature_flags/#per-step-stats