### PR TITLE
grafana_dashboards variable

### DIFF
--- a/group_vars/grafana/vars.yml
+++ b/group_vars/grafana/vars.yml
@@ -12,9 +12,11 @@ grafana_ini:
   metrics:
     enabled: true
 
-  datasources:
-    - name: "Prometheus"
-      type: "prometheus"
-      access: "proxy"
-      url: "http://{{ ansible_host }}:9090"
-      isDefault: true
+grafana_datasources:
+  - name: "Prometheus"
+    type: "prometheus"
+    access: "proxy"
+    url: "http://{{ ansible_host | default(inventory_hostname) }}:9090"
+    isDefault: true
+
+grafana_dashboards: []


### PR DESCRIPTION
An earlier version of demo-site included the variable `grafana_dashboards: []` which I thought was a nice reminder of what the variable name is and that it should probably be configured.    We are using `grafana_dashboards`.  

If you do set that variable now, the grafana role complains `grafana_datasources` is missing.   

Based on that discovery, it seems the renaming of `grafana_datasources` to `datasources` in this vars.yml file didn't match the upstream grafana role and so maybe "datasources" is being ignored.  

This PR partially reverts the file `group_vars/grafana/vars.yml` to a previous state.    Things are working better. but if you believe I am missing other details about the topic and this is incorrect, let me know.  